### PR TITLE
fix: changed to work with Jest 26 and Jest 27

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
 const fs = require( 'fs' );
 
-const TestRunner = require( 'jest-runner' );
+const JestRunner = require( 'jest-runner' );
 const { parse } = require( 'jest-docblock' );
+
+const TestRunner = Object.prototype.hasOwnProperty.call(JestRunner, 'default') ? JestRunner.default : JestRunner;
 
 const ARG_PREFIX = '--group=';
 


### PR DESCRIPTION
Jest 27 now uses ES6 style default exports ( `exports.default = TestRunner` vs `module.exports = TestRunner` ). This change looks to see if there is a property `default`  on the import, and then uses it if it does exist.

There may be a better way of doing this, but I needed a quick patch locally and this worked. 